### PR TITLE
feat: add Material 3 tooltip component

### DIFF
--- a/demo/components/expressive-component.js
+++ b/demo/components/expressive-component.js
@@ -15,6 +15,7 @@ import 'material/slider/slider.js'
 import 'material/switch/switch.js'
 import 'material/radio/radio.js'
 import 'material/checkbox/checkbox.js'
+import 'material/tooltip/tooltip.js'
 import { snack } from 'material/snackbar/snackbar.js'
 import { styles as sharedStyles } from './styles.js'
 import { styles as typography } from '../../typography/md-typescale-styles.js'
@@ -198,6 +199,22 @@ class ExpressiveComponent extends LitElement {
             style="--md-icon-button-icon-size: 16px; --md-icon-button-container-width: 24px; --md-icon-button-container-height: 24px;">
             <md-icon>content_copy</md-icon>
           </md-icon-button>
+        </div>
+        <div>
+          Tooltips:
+          <md-tooltip text="This is a plain tooltip">
+            <md-button>Hover me</md-button>
+          </md-tooltip>
+
+          <md-tooltip type="rich">
+            <md-button>Hover me too</md-button>
+            <div slot="headline">Headline</div>
+            <div slot="text">This is a rich tooltip with more details and actions.</div>
+            <div slot="actions" class="flex g12">
+              <md-button color="text" size="x-small">Action 1</md-button>
+              <md-button color="text" size="x-small">Action 2</md-button>
+            </div>
+          </md-tooltip>
         </div>
         <!-- Buttons -->
         <h3>Button sizes</h3>

--- a/demo/components/styles.js
+++ b/demo/components/styles.js
@@ -34,6 +34,9 @@ export const styles = css`
     width: 100%;
   }
 
+  .g4 {
+    gap: 4px;
+  }
   .g8 {
     gap: 8px;
   }

--- a/demo/css/styles.css
+++ b/demo/css/styles.css
@@ -97,6 +97,12 @@ a:hover {
   flex-direction: column;
 }
 
+.g4 {
+  gap: 4px;
+}
+.g8 {
+  gap: 8px;
+}
 .g12 {
   gap: 12px;
 }

--- a/demo/tooltip.html
+++ b/demo/tooltip.html
@@ -18,27 +18,39 @@
       }
     }
   </script>
-  <style>
-    body {
-      font-family: Roboto, sans-serif;
-      padding: 50px;
-      display: flex;
-      gap: 50px;
-    }
-  </style>
+
+   <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap"
+      as="style"
+      onload="this.onload=null;this.rel='stylesheet'" />
+    <link
+      rel="preload"
+      href="https://fonts.googleapis.com/css2?family=Google+Sans+Flex:wght@400;500;700&display=swap"
+      as="style"
+      onload="this.onload=null;this.rel='stylesheet'" />
+
+    <link rel="icon" href="./images/material.jpeg" />
+
+    <link rel="stylesheet" href="./css/styles.css" />
 </head>
 <body>
   <script type="module" src="../tooltip/tooltip.js"></script>
+  <script type="module" src="../buttons/button.js"></script>
 
-  <md-tooltip title="This is a plain tooltip">
-    <button>Hover me</button>
+  <md-tooltip text="This is a plain tooltip">
+    <md-button>Hover me</md-button>
   </md-tooltip>
 
-  <md-tooltip variant="rich" title="This is a rich tooltip with more details and actions.">
-    <button>Hover me too</button>
-    <div slot="actions">
-      <button>Action 1</button>
-      <button>Action 2</button>
+  <md-tooltip type="rich">
+    <md-button>Hover me too</md-button>
+    <div slot="headline">Headline</div>
+    <div slot="text">This is a rich tooltip with more details and actions.</div>
+    <div slot="actions" class="flex g12">
+      <md-button color="text" size="x-small">Action 1</md-button>
+      <md-button color="text" size="x-small">Action 2</md-button>
     </div>
   </md-tooltip>
 

--- a/demo/tooltip.html
+++ b/demo/tooltip.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tooltip Demo</title>
+  <script type="importmap">
+    {
+      "imports": {
+        "lit": "https://cdn.jsdelivr.net/npm/lit@3/index.js",
+        "lit/": "https://cdn.jsdelivr.net/npm/lit@3/",
+        "@lit/localize": "https://cdn.jsdelivr.net/npm/@lit/localize/lit-localize.js",
+        "@lit/reactive-element": "https://cdn.jsdelivr.net/npm/@lit/reactive-element@1/reactive-element.js",
+        "@lit/reactive-element/": "https://cdn.jsdelivr.net/npm/@lit/reactive-element@1/",
+        "lit-element/lit-element.js": "https://cdn.jsdelivr.net/npm/lit-element@4/lit-element.js",
+        "lit-html": "https://cdn.jsdelivr.net/npm/lit-html@3/lit-html.js",
+        "lit-html/": "https://cdn.jsdelivr.net/npm/lit-html@3/"
+      }
+    }
+  </script>
+  <style>
+    body {
+      font-family: Roboto, sans-serif;
+      padding: 50px;
+      display: flex;
+      gap: 50px;
+    }
+  </style>
+</head>
+<body>
+  <script type="module" src="../tooltip/tooltip.js"></script>
+
+  <md-tooltip title="This is a plain tooltip">
+    <button>Hover me</button>
+  </md-tooltip>
+
+  <md-tooltip variant="rich" title="This is a rich tooltip with more details and actions.">
+    <button>Hover me too</button>
+    <div slot="actions">
+      <button>Action 1</button>
+      <button>Action 2</button>
+    </div>
+  </md-tooltip>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "publishConfig": {
     "access": "public"
   },

--- a/shared/shared.css.js
+++ b/shared/shared.css.js
@@ -20,8 +20,14 @@ export const sharedStyles = css`
     width: 100%;
   }
 
+  .g4 {
+    gap: 4px;
+  }
   .g8 {
     gap: 8px;
+  }
+  .g12 {
+    gap: 12px;
   }
   .g16 {
     gap: 16px;

--- a/tooltip/tooltip.js
+++ b/tooltip/tooltip.js
@@ -1,0 +1,147 @@
+import { html, LitElement, css } from 'lit'
+import { property } from 'lit/decorators.js'
+import { classMap } from 'lit/directives/class-map.js'
+
+export class Tooltip extends LitElement {
+  static properties = {
+    title: { type: String },
+    variant: { type: String }, // 'plain' or 'rich'
+    open: { type: Boolean, reflect: true }
+  }
+
+  constructor() {
+    super(...arguments)
+    this.title = ''
+    this.variant = 'plain'
+    this.open = false
+    this.showTimeout = null
+    this.hideTimeout = null
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.addEventListener('mouseenter', this.handleMouseEnter)
+    this.addEventListener('mouseleave', this.handleMouseLeave)
+    this.addEventListener('focus', this.handleFocus, true)
+    this.addEventListener('blur', this.handleBlur, true)
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback()
+    this.removeEventListener('mouseenter', this.handleMouseEnter)
+    this.removeEventListener('mouseleave', this.handleMouseLeave)
+    this.removeEventListener('focus', this.handleFocus, true)
+    this.removeEventListener('blur', this.handleBlur, true)
+    this.clearTimeouts()
+  }
+
+  handleMouseEnter = () => {
+    this.clearTimeouts()
+    this.showTimeout = setTimeout(() => {
+      this.open = true
+    }, 500)
+  }
+
+  handleMouseLeave = () => {
+    this.clearTimeouts()
+    this.hideTimeout = setTimeout(() => {
+      this.open = false
+    }, 100) // Plain tooltips often stay slightly after hover out
+  }
+
+  handleFocus = () => {
+    this.clearTimeouts()
+    this.open = true
+  }
+
+  handleBlur = () => {
+    this.clearTimeouts()
+    this.open = false
+  }
+
+  clearTimeouts() {
+    if (this.showTimeout) clearTimeout(this.showTimeout)
+    if (this.hideTimeout) clearTimeout(this.hideTimeout)
+  }
+
+  render() {
+    const classes = {
+      'md3-tooltip': true,
+      'md3-tooltip--rich': this.variant === 'rich'
+    }
+
+    return html`
+      <div class="target">
+        <slot></slot>
+      </div>
+      <div class=${classMap(classes)} role="tooltip" aria-hidden=${!this.open}>
+        <div class="content">${this.title}<slot name="content"></slot></div>
+        ${this.variant === 'rich' ? html`<div class="actions"><slot name="actions"></slot></div>` : ''}
+      </div>
+    `
+  }
+
+  static styles = [
+    css`
+      :host {
+        display: inline-block;
+        position: relative;
+        --_container-color: var(--md-sys-color-inverse-surface, #313033);
+        --_text-color: var(--md-sys-color-inverse-on-surface, #f4eff4);
+        --_rich-container-color: var(--md-sys-color-surface-container, #f3edf7);
+        --_rich-text-color: var(--md-sys-color-on-surface-variant, #49454f);
+      }
+
+      .md3-tooltip {
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        margin-top: 4px;
+        background-color: var(--_container-color);
+        color: var(--_text-color);
+        border-radius: 4px;
+        padding: 4px 8px;
+        font-family: var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto));
+        font-size: var(--md-sys-typescale-body-small-size, 12px);
+        line-height: var(--md-sys-typescale-body-small-line-height, 16px);
+        font-weight: var(--md-sys-typescale-body-small-weight, 400);
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.2s, visibility 0.2s;
+        z-index: 100;
+        pointer-events: none;
+        white-space: nowrap;
+        box-sizing: border-box;
+      }
+
+      :host([open]) .md3-tooltip {
+        opacity: 1;
+        visibility: visible;
+      }
+
+      .md3-tooltip.md3-tooltip--rich {
+        background-color: var(--_rich-container-color);
+        color: var(--_rich-text-color);
+        border-radius: 12px;
+        padding: 12px 16px;
+        font-family: var(--md-sys-typescale-body-medium-font, var(--md-ref-typeface-plain, Roboto));
+        font-size: var(--md-sys-typescale-body-medium-size, 14px);
+        line-height: var(--md-sys-typescale-body-medium-line-height, 20px);
+        box-shadow: 0px 4px 8px 3px rgba(0, 0, 0, 0.15), 0px 1px 3px rgba(0, 0, 0, 0.3);
+        pointer-events: auto;
+        white-space: normal;
+        min-width: 200px;
+        max-width: 320px;
+      }
+
+      .actions {
+        margin-top: 8px;
+        display: flex;
+        gap: 8px;
+      }
+    `
+  ]
+}
+
+customElements.define('md-tooltip', Tooltip)

--- a/tooltip/tooltip.js
+++ b/tooltip/tooltip.js
@@ -47,7 +47,7 @@ export class Tooltip extends LitElement {
     this.clearTimeouts()
     this.hideTimeout = setTimeout(() => {
       this.open = false
-    }, 100) // Plain tooltips often stay slightly after hover out
+    }, 500) // Increased delay to allow interaction with rich tooltips
   }
 
   handleFocus = () => {

--- a/tooltip/tooltip.js
+++ b/tooltip/tooltip.js
@@ -72,9 +72,7 @@ export class Tooltip extends LitElement {
     }
 
     return html`
-      <div class="target">
-        <slot></slot>
-      </div>
+      <slot></slot>
       <div class=${classMap(classes)} role="tooltip" aria-hidden=${!this.open}>
         <div class="content">
           ${this.type === 'rich' ? html`<div class="headline">${this.headline}<slot name="headline"></slot></div>` : ''}

--- a/tooltip/tooltip.js
+++ b/tooltip/tooltip.js
@@ -71,6 +71,7 @@ export class Tooltip extends LitElement {
       'md-tooltip--rich': this.type === 'rich',
     }
 
+    // todo: only render headline div if this.headline or headline slot has content
     return html`
       <div class="target">
         <slot></slot>

--- a/tooltip/tooltip.js
+++ b/tooltip/tooltip.js
@@ -1,18 +1,19 @@
 import { html, LitElement, css } from 'lit'
-import { property } from 'lit/decorators.js'
 import { classMap } from 'lit/directives/class-map.js'
 
 export class Tooltip extends LitElement {
   static properties = {
-    title: { type: String },
-    variant: { type: String }, // 'plain' or 'rich'
-    open: { type: Boolean, reflect: true }
+    type: { type: String }, // 'plain' or 'rich'
+    headline: { type: String },
+    text: { type: String },
+    open: { type: Boolean, reflect: true },
   }
 
   constructor() {
-    super(...arguments)
-    this.title = ''
-    this.variant = 'plain'
+    super()
+    this.headline = ''
+    this.text = ''
+    this.type = 'plain'
     this.open = false
     this.showTimeout = null
     this.hideTimeout = null
@@ -66,8 +67,8 @@ export class Tooltip extends LitElement {
 
   render() {
     const classes = {
-      'md3-tooltip': true,
-      'md3-tooltip--rich': this.variant === 'rich'
+      'md-tooltip': true,
+      'md-tooltip--rich': this.type === 'rich',
     }
 
     return html`
@@ -75,8 +76,11 @@ export class Tooltip extends LitElement {
         <slot></slot>
       </div>
       <div class=${classMap(classes)} role="tooltip" aria-hidden=${!this.open}>
-        <div class="content">${this.title}<slot name="content"></slot></div>
-        ${this.variant === 'rich' ? html`<div class="actions"><slot name="actions"></slot></div>` : ''}
+        <div class="content">
+          ${this.type === 'rich' ? html`<div class="headline">${this.headline}<slot name="headline"></slot></div>` : ''}
+          ${this.text}<slot name="text"></slot>
+        </div>
+        ${this.type === 'rich' ? html`<div class="actions"><slot name="actions"></slot></div>` : ''}
       </div>
     `
   }
@@ -92,7 +96,7 @@ export class Tooltip extends LitElement {
         --_rich-text-color: var(--md-sys-color-on-surface-variant, #49454f);
       }
 
-      .md3-tooltip {
+      .md-tooltip {
         position: absolute;
         top: 100%;
         left: 50%;
@@ -108,19 +112,25 @@ export class Tooltip extends LitElement {
         font-weight: var(--md-sys-typescale-body-small-weight, 400);
         opacity: 0;
         visibility: hidden;
-        transition: opacity 0.2s, visibility 0.2s;
+        transition:
+          opacity 0.2s,
+          visibility 0.2s;
         z-index: 100;
         pointer-events: none;
         white-space: nowrap;
         box-sizing: border-box;
       }
 
-      :host([open]) .md3-tooltip {
+      :host([open]) .md-tooltip {
         opacity: 1;
         visibility: visible;
       }
 
-      .md3-tooltip.md3-tooltip--rich {
+      .headline {
+        font-weight: 500;
+      }
+
+      .md-tooltip.md-tooltip--rich {
         background-color: var(--_rich-container-color);
         color: var(--_rich-text-color);
         border-radius: 12px;
@@ -128,7 +138,9 @@ export class Tooltip extends LitElement {
         font-family: var(--md-sys-typescale-body-medium-font, var(--md-ref-typeface-plain, Roboto));
         font-size: var(--md-sys-typescale-body-medium-size, 14px);
         line-height: var(--md-sys-typescale-body-medium-line-height, 20px);
-        box-shadow: 0px 4px 8px 3px rgba(0, 0, 0, 0.15), 0px 1px 3px rgba(0, 0, 0, 0.3);
+        box-shadow:
+          0px 4px 8px 3px rgba(0, 0, 0, 0.15),
+          0px 1px 3px rgba(0, 0, 0, 0.3);
         pointer-events: auto;
         white-space: normal;
         min-width: 200px;
@@ -140,7 +152,7 @@ export class Tooltip extends LitElement {
         display: flex;
         gap: 8px;
       }
-    `
+    `,
   ]
 }
 


### PR DESCRIPTION
Implemented the Material 3 Tooltip component as requested. 
Features:
- `md-tooltip` custom element based on Lit.
- Plain and Rich variants via the `variant` attribute.
- Built-in hover/focus tracking for accessibility and correct show/hide interactions with appropriate timeouts.
- Scoped styling adhering to Material 3 tokens.
- Demo page added for ease of verification.

---
*PR created automatically by Jules for task [2393445607242444707](https://jules.google.com/task/2393445607242444707) started by @treeder*